### PR TITLE
Upgrading to rn-0.19 and react-native.d.ts@56295f5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ npm-debug.log
 .tscache
 gen/
 .baseDir.ts
+.vscode

--- a/package.json
+++ b/package.json
@@ -1,23 +1,24 @@
 {
-    "name": "RNTSExplorer",
-    "version": "0.0.1",
-    "description": "React Native UI Explorer in Typescript",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/bgrieder/RNTSExplorer.git"
-    },
-    "private": false,
-    "scripts": {
-        "start": "react-native start"
-    },
-    "dependencies": {
-        "react-mixin": "^3.0.3",
-        "react-native": "^0.16.0",
-        "react-timer-mixin": "^0.13.3"
-    },
-    "devDependencies": {
-        "grunt": "^0.4.5",
-        "grunt-contrib-clean": "^0.7.0",
-        "grunt-ts": "^5.3.0-beta.2"
-    }
+  "name": "RNTSExplorer",
+  "version": "0.0.1",
+  "description": "React Native UI Explorer in Typescript",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bgrieder/RNTSExplorer.git"
+  },
+  "private": false,
+  "scripts": {
+    "start": "react-native start"
+  },
+  "dependencies": {
+    "react-mixin": "3.0.4",
+    "react-native": "0.19.0",
+    "react-timer-mixin": "0.13.3"
+  },
+  "devDependencies": {
+    "grunt": "0.4.5",
+    "grunt-contrib-clean": "1.0.0",
+    "grunt-ts": "5.5.0-beta.2",
+    "typescript": "1.8.9"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
         "outDir": "gen",
         "jsx": "react",
         "sourceMap": true,
-        "experimentalDecorators": true
+        "experimentalDecorators": true,
+        "allowJs": true
     },
     "compileOnSave": true,
     "filesGlob": [
@@ -68,5 +69,8 @@
         "typings/react-native/react-native.d.ts",
         "typings/react-timer-mixin/react-timer-mixin.d.ts",
         "typings/react/react.d.ts"
+    ],
+    "exclude": [
+        "node_modules"
     ]
 }

--- a/typescript/RNTSExample.ts
+++ b/typescript/RNTSExample.ts
@@ -3,7 +3,7 @@
  * This file is not part of the original UIExplorer
  */
 
-import React from 'react-native'
+import * as React from 'react-native';
 
 interface RNTSExample extends React.ComponentClass<any> {
 

--- a/typescript/RNTSExplorer.tsx
+++ b/typescript/RNTSExplorer.tsx
@@ -17,7 +17,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 const { NavigatorIOS } = React;
 
 import RNTSExplorerList from './RNTSExplorerList'

--- a/typescript/RNTSExplorerBlock.tsx
+++ b/typescript/RNTSExplorerBlock.tsx
@@ -16,7 +16,7 @@ import ValidationMap = __React.ValidationMap;
  */
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 const {
           StyleSheet,
           Text,

--- a/typescript/RNTSExplorerList.tsx
+++ b/typescript/RNTSExplorerList.tsx
@@ -17,7 +17,7 @@ import RNTSExampleModule from "./RNTSExampleModule";
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 const {
           AppRegistry,
           ListView,

--- a/typescript/RNTSExplorerPage.tsx
+++ b/typescript/RNTSExplorerPage.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 const {
           ScrollView,
           StyleSheet,

--- a/typescript/RNTSExplorerTitle.tsx
+++ b/typescript/RNTSExplorerTitle.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 const {
           StyleSheet,
           Text,

--- a/typescript/apis/ActionSheetIOSExample.tsx
+++ b/typescript/apis/ActionSheetIOSExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/apis/AdSupportIOSExample.tsx
+++ b/typescript/apis/AdSupportIOSExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/apis/AlertIOSExample.tsx
+++ b/typescript/apis/AlertIOSExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/apis/AppStateIOSExample.tsx
+++ b/typescript/apis/AppStateIOSExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/apis/AsyncStorageExample.tsx
+++ b/typescript/apis/AsyncStorageExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/apis/BorderExample.tsx
+++ b/typescript/apis/BorderExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/apis/CameraRollExample.ios.tsx
+++ b/typescript/apis/CameraRollExample.ios.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/apis/CameraRollView.ios.tsx
+++ b/typescript/apis/CameraRollView.ios.tsx
@@ -17,7 +17,7 @@ import ValidationMap = __React.ValidationMap;
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/apis/GeolocationExample.tsx
+++ b/typescript/apis/GeolocationExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/apis/LayoutExample.tsx
+++ b/typescript/apis/LayoutExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/apis/NetInfoExample.tsx
+++ b/typescript/apis/NetInfoExample.tsx
@@ -19,7 +19,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/apis/PanResponderExample.tsx
+++ b/typescript/apis/PanResponderExample.tsx
@@ -18,7 +18,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/apis/PointerEventsExample.tsx
+++ b/typescript/apis/PointerEventsExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/apis/PushNotificationIOSExample.tsx
+++ b/typescript/apis/PushNotificationIOSExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/apis/StatusBarIOSExample.tsx
+++ b/typescript/apis/StatusBarIOSExample.tsx
@@ -17,7 +17,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/apis/TimerExample.tsx
+++ b/typescript/apis/TimerExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import * as reactMixin from 'react-mixin'
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'

--- a/typescript/apis/VibrationIOSExample.tsx
+++ b/typescript/apis/VibrationIOSExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/components/ActivityIndicatorIOSExample.tsx
+++ b/typescript/components/ActivityIndicatorIOSExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import * as reactMixin from 'react-mixin'
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'

--- a/typescript/components/DatePickerIOSExample.tsx
+++ b/typescript/components/DatePickerIOSExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/components/ImageCapInsetsExample.tsx
+++ b/typescript/components/ImageCapInsetsExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/components/ImageExample.tsx
+++ b/typescript/components/ImageExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/components/ListViewExample.tsx
+++ b/typescript/components/ListViewExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 import RNTSExplorerPage from '../RNTSExplorerPage'

--- a/typescript/components/ListViewPagingExample.tsx
+++ b/typescript/components/ListViewPagingExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/components/MapViewExample.tsx
+++ b/typescript/components/MapViewExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/components/NavigatorIOSExample.tsx
+++ b/typescript/components/NavigatorIOSExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import createExamplePage from '../createExamplePage'
 
 import ViewExample from './ViewExample'

--- a/typescript/components/PickerIOSExample.tsx
+++ b/typescript/components/PickerIOSExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/components/ScrollViewExample.tsx
+++ b/typescript/components/ScrollViewExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/components/SliderIOSExample.tsx
+++ b/typescript/components/SliderIOSExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/components/SwitchIOSExample.tsx
+++ b/typescript/components/SwitchIOSExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/components/TabBarIOSExample.tsx
+++ b/typescript/components/TabBarIOSExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/components/TextExample.ios.tsx
+++ b/typescript/components/TextExample.ios.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/components/TextInputExample.tsx
+++ b/typescript/components/TextInputExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/components/TouchableExample.tsx
+++ b/typescript/components/TouchableExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/components/ViewExample.tsx
+++ b/typescript/components/ViewExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExanpleModule from '../RNTSExampleModule'
 

--- a/typescript/components/WebViewExample.tsx
+++ b/typescript/components/WebViewExample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import RNTSExample from '../RNTSExample'
 import RNTSExampleModule from '../RNTSExampleModule'
 

--- a/typescript/components/navigator/BreadcrumbNavSample.tsx
+++ b/typescript/components/navigator/BreadcrumbNavSample.tsx
@@ -16,7 +16,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 const {
           PixelRatio,
           Navigator,

--- a/typescript/components/navigator/JumpingNavSample.tsx
+++ b/typescript/components/navigator/JumpingNavSample.tsx
@@ -17,7 +17,7 @@
 
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 const {
           Navigator,
           PixelRatio,

--- a/typescript/components/navigator/NavigationBarSample.tsx
+++ b/typescript/components/navigator/NavigationBarSample.tsx
@@ -15,7 +15,7 @@
  *
  */
 
-import React from 'react-native'
+import * as React from 'react-native';
 const {
           PixelRatio,
           Navigator,

--- a/typescript/components/navigator/NavigatorExample.tsx
+++ b/typescript/components/navigator/NavigatorExample.tsx
@@ -16,7 +16,7 @@
  */
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 const {
           Navigator,
           PixelRatio,

--- a/typescript/createExamplePage.tsx
+++ b/typescript/createExamplePage.tsx
@@ -15,7 +15,7 @@
  */
 'use strict'
 
-import React from 'react-native'
+import * as React from 'react-native';
 import invariant from 'invariant'
 
 import RNTSExplorerBlock from './RNTSExplorerBlock'

--- a/typings/react-native/react-native.d.ts
+++ b/typings/react-native/react-native.d.ts
@@ -1,7 +1,7 @@
-// Type definitions for react-native 0.14
+// Type definitions for react-native 0.19
 // Project: https://github.com/facebook/react-native
 // Definitions by: Bruno Grieder <https://github.com/bgrieder>
-// Definitions: https://github.com/borisyankov/DefinitelyTyped
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
@@ -976,6 +976,31 @@ declare namespace  __React {
      * whether that is a UIView, <div>, android.view, etc.
      */
     export interface ViewStatic extends NativeComponent, React.ComponentClass<ViewProperties> {
+
+    }
+
+    /**
+     * @see https://facebook.github.io/react-native/docs/viewpagerandroid.html#props
+     */
+
+
+    export interface ViewPagerAndroidOnPageScrollEventData {
+        position: number;
+        offset: number;
+    }
+
+    export interface ViewPagerAndroidOnPageSelectedEventData {
+        position: number;
+    }
+
+    export interface ViewPagerAndroidProperties extends ViewProperties {
+        initialPage?: number;
+        onPageScroll?: ( event: NativeSyntheticEvent<ViewPagerAndroidOnPageScrollEventData> ) => void;
+        onPageSelected?: ( event: NativeSyntheticEvent<ViewPagerAndroidOnPageSelectedEventData> ) => void;
+        keyboardDismissMode?: string; /* enum('none', 'on-drag') */
+    }
+
+    export interface ViewPagerAndroidStatic extends NativeComponent, React.ComponentClass<ViewPagerAndroidProperties> {
 
     }
 
@@ -2712,7 +2737,7 @@ declare namespace  __React {
          * Fires at most once per frame during scrolling.
          * The frequency of the events can be contolled using the scrollEventThrottle prop.
          */
-        onScroll?: () => void
+        onScroll?: (event?: { nativeEvent: NativeScrollEvent }) => void
 
         /**
          * Experimental: When true offscreen child views (whose `overflow` value is
@@ -2853,7 +2878,7 @@ declare namespace  __React {
      *
      * @see https://facebook.github.io/react-native/docs/appstateios.html#content
      */
-    export interface AppStateIOSStatic {
+    export interface AppStateStatic {
         currentState: string
         addEventListener( type: string, listener: ( state: string ) => void ): void
         removeEventListener( type: string, listener: ( state: string ) => void ): void
@@ -3364,6 +3389,9 @@ declare namespace  __React {
     export var View: ViewStatic
     export type View = ViewStatic
 
+    export var ViewPagerAndroid: ViewPagerAndroidStatic
+    export type ViewPagerAndroid = ViewPagerAndroidStatic
+
     export var WebView: WebViewStatic
     export type WebView = WebViewStatic
 
@@ -3378,8 +3406,11 @@ declare namespace  __React {
     export var AlertIOS: AlertIOSStatic
     export type AlertIOS = AlertIOSStatic
 
-    export var AppStateIOS: AppStateIOSStatic
-    export type AppStateIOS = AppStateIOSStatic
+    export var AppState : AppStateStatic;
+    export type AppState = AppStateStatic;
+
+    export var AppStateIOS: AppStateStatic
+    export type AppStateIOS = AppStateStatic
 
     export var AsyncStorage: AsyncStorageStatic
     export type AsyncStorage = AsyncStorageStatic
@@ -3459,7 +3490,7 @@ declare namespace  __React {
 declare module "react-native" {
 
     import ReactNative = __React
-    export default ReactNative
+    export = ReactNative
 }
 
 declare var global: __React.GlobalStatic
@@ -3469,7 +3500,7 @@ declare function require( name: string ): any
 
 //TODO: BGR: this is a left-over from the initial port. Not sure it makes any sense
 declare module "Dimensions" {
-    import React from 'react-native';
+    import * as React from 'react-native';
 
     interface Dimensions {
         get( what: string ): React.ScaledSize;


### PR DESCRIPTION
This PR upgrades `RNTSExplorer` to [react-native 0.19](https://github.com/facebook/react-native/releases/tag/v0.19.0) and https://github.com/DefinitelyTyped/DefinitelyTyped/commit/56295f5058cac7ae458540423c50ac2dcf9fc711.

#### Details
- updated all dependencies using `npm-check-updates -u`
- added latest typescript compiler via `npm install typescript --save-dev`
- "nailed" all versions by removing `^`
- changed every: 
  - `import React from 'react-native'` to 
  - `import * as React from 'react-native';` 